### PR TITLE
Make sure badgehub frontend can connect to the network

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -1,1 +1,1 @@
-BADGEHUB_API_BASEURL=http://badgehub_api:8001/
+BADGEHUB_API_BASEURL=http://badgehub-backend:8081/

--- a/docker-compose-production.yaml
+++ b/docker-compose-production.yaml
@@ -1,5 +1,5 @@
 services:
-  website:
+  badgehub-frontend:
     build: .
     ports:
       - "8003:3000"

--- a/docker-compose-production.yaml
+++ b/docker-compose-production.yaml
@@ -6,6 +6,8 @@ services:
     restart: always
     env_file:
       - ".env.prod"
+    networks:
+      - badgehub_network
 
 networks:
   badgehub_network:


### PR DESCRIPTION
Within the docker container for frontend I could ping the services. 

/app $ ping badgehub-frontend
PING badgehub-frontend (10.10.3.2): 56 data bytes
64 bytes from 10.10.3.2: seq=0 ttl=42 time=0.128 ms
64 bytes from 10.10.3.2: seq=1 ttl=42 time=0.166 ms
^C
--- badgehub-frontend ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max = 0.128/0.147/0.166 ms
/app $ ping badgehub-backend
PING badgehub-backend (10.10.3.3): 56 data bytes
64 bytes from 10.10.3.3: seq=0 ttl=42 time=0.313 ms
64 bytes from 10.10.3.3: seq=1 ttl=42 time=0.086 ms
^C
--- badgehub-backend ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max = 0.086/0.199/0.313 ms
/app $ 

