### PR TITLE
Render the app listing on the server

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import {
   getApps,
   getCategories,

--- a/src/app/api/restricted.js
+++ b/src/app/api/restricted.js
@@ -1,7 +1,7 @@
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "./auth/[...nextauth]";
 
-export default async function(req, res) {
+export default async function RestrictedPage(req, res) {
   const session = await getServerSession(req, res, authOptions);
 
   if (session) {
@@ -15,4 +15,4 @@ export default async function(req, res) {
         "You must be signed in to view the protected content on this page.",
     });
   }
-};
+}

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -1,22 +1,6 @@
-<<<<<<< HEAD
-"use client";
-
-import { AppList } from "@/components/AppList";
-import { SessionProvider } from "next-auth/react";
-import { LoginButton } from "@/components/LoginButton";
-import { useEffect, useState } from "react";
-||||||| parent of 4ace4de (Render the app listing on the server)
-"use client"
-
-import {AppList} from "@/components/AppList";
-import {SessionProvider} from "next-auth/react";
-import {LoginButton} from "@/components/LoginButton";
-import {useEffect, useState} from "react";
-=======
 import { AppList } from "@/components/AppList";
 import { LoginButton } from "@/components/LoginButton";
 import { useEffect, useState } from "react";
->>>>>>> 4ace4de (Render the app listing on the server)
 import {
   getAppsResponse,
   getCategoriesResponse,

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -38,7 +38,7 @@ export default async function Listing({
   return (
     <>
       <LoginButton />
-      {data ? <AppList data={data} /> : <p>Loading new data...</p>}
+      <AppList data={data} />
     </>
   );
 }

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -1,9 +1,22 @@
+<<<<<<< HEAD
 "use client";
 
 import { AppList } from "@/components/AppList";
 import { SessionProvider } from "next-auth/react";
 import { LoginButton } from "@/components/LoginButton";
 import { useEffect, useState } from "react";
+||||||| parent of 4ace4de (Render the app listing on the server)
+"use client"
+
+import {AppList} from "@/components/AppList";
+import {SessionProvider} from "next-auth/react";
+import {LoginButton} from "@/components/LoginButton";
+import {useEffect, useState} from "react";
+=======
+import { AppList } from "@/components/AppList";
+import { LoginButton } from "@/components/LoginButton";
+import { useEffect, useState } from "react";
+>>>>>>> 4ace4de (Render the app listing on the server)
 import {
   getAppsResponse,
   getCategoriesResponse,
@@ -16,23 +29,32 @@ export interface SearchParams {
   device: string;
 }
 
-export default function Listing({
+export default async function Listing({
   searchParams,
 }: {
   searchParams: Partial<SearchParams>;
 }) {
-  const [data, setData] = useState<
-    [getAppsResponse, getCategoriesResponse, getDevicesResponse] | null
-  >(null);
-
-  useEffect(() => {
-    getAppData(searchParams).then((data) => setData(data));
-  }, [searchParams]);
+  let data;
+  try {
+    data = await getAppData(searchParams);
+  } catch (e) {
+    if (!(e instanceof Error)) {
+      return <p>Caught object that wasn&amp;t an error.</p>;
+    }
+    return (
+      <>
+        <p>Error while rendering</p>
+        <code>
+          <pre>{JSON.stringify(e.message)}</pre>
+        </code>
+      </>
+    );
+  }
 
   return (
-    <SessionProvider>
+    <>
       <LoginButton />
       {data ? <AppList data={data} /> : <p>Loading new data...</p>}
-    </SessionProvider>
+    </>
   );
 }

--- a/src/app/apps/page.tsx
+++ b/src/app/apps/page.tsx
@@ -1,11 +1,5 @@
 import { AppList } from "@/components/AppList";
 import { LoginButton } from "@/components/LoginButton";
-import { useEffect, useState } from "react";
-import {
-  getAppsResponse,
-  getCategoriesResponse,
-  getDevicesResponse,
-} from "@/badgehub-api-client/generated/swagger/public/public";
 import { getAppData } from "../actions";
 
 export interface SearchParams {

--- a/src/badgehub-api-client/generated/swagger/public/public.ts
+++ b/src/badgehub-api-client/generated/swagger/public/public.ts
@@ -24,7 +24,7 @@ export type getDevicesResponse = {
 export const getGetDevicesUrl = () => {
 
 
-  return `http://localhost:8001/api/v3/devices`
+  return `https://api-staging.badgehub.nl/api/v3/devices`
 }
 
 export const getDevices = async ( options?: RequestInit): Promise<getDevicesResponse> => {
@@ -55,7 +55,7 @@ export type getCategoriesResponse = {
 export const getGetCategoriesUrl = () => {
 
 
-  return `http://localhost:8001/api/v3/categories`
+  return `https://api-staging.badgehub.nl/api/v3/categories`
 }
 
 export const getCategories = async ( options?: RequestInit): Promise<getCategoriesResponse> => {
@@ -95,7 +95,7 @@ export const getGetAppsUrl = (params?: GetAppsParams,) => {
     }
   });
 
-  return normalizedParams.size ? `http://localhost:8001/api/v3/apps?${normalizedParams.toString()}` : `http://localhost:8001/api/v3/apps`
+  return normalizedParams.size ? `https://api-staging.badgehub.nl/api/v3/apps?${normalizedParams.toString()}` : `https://api-staging.badgehub.nl/api/v3/apps`
 }
 
 export const getApps = async (params?: GetAppsParams, options?: RequestInit): Promise<getAppsResponse> => {
@@ -126,7 +126,7 @@ export type getAppDetailsResponse = {
 export const getGetAppDetailsUrl = (slug: string,) => {
 
 
-  return `http://localhost:8001/api/v3/apps/${slug}`
+  return `https://api-staging.badgehub.nl/api/v3/apps/${slug}`
 }
 
 export const getAppDetails = async (slug: string, options?: RequestInit): Promise<getAppDetailsResponse> => {

--- a/src/components/LoginButton/index.tsx
+++ b/src/components/LoginButton/index.tsx
@@ -1,7 +1,17 @@
-import { useSession, signIn, signOut } from "next-auth/react";
+"use client";
+
+import { useSession, signIn, signOut, SessionProvider } from "next-auth/react";
 import styles from "./LoginButton.module.css";
 
 export function LoginButton() {
+  return (
+    <SessionProvider>
+      <LoginButtonInternal />
+    </SessionProvider>
+  );
+}
+
+export function LoginButtonInternal() {
   const { data: session, status } = useSession();
 
   let html;


### PR DESCRIPTION
- Pushes the `SessionProvider` into a wrapper component for `LoginButton` so that it can be used from within a server component
- Modifies app listing page to provide app list necessary data
- Updates orval client in the repo to use the staging API by default